### PR TITLE
Switch to MouseKeyHook package

### DIFF
--- a/MacroRecorderPro/MacroRecorderPro.csproj
+++ b/MacroRecorderPro/MacroRecorderPro.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="NAudio" Version="2.2.1" />
-    <PackageReference Include="GlobalMouseKeyHook" Version="5.6.0" />
+    <PackageReference Include="MouseKeyHook" Version="5.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MacroRecorderPro/README.md
+++ b/MacroRecorderPro/README.md
@@ -33,7 +33,7 @@ Install-Package FontAwesome.Sharp -Version 6.3.0
 Install-Package Newtonsoft.Json -Version 13.0.3
 Install-Package System.Drawing.Common -Version 7.0.0
 Install-Package NAudio -Version 2.2.1
-Install-Package GlobalMouseKeyHook -Version 5.6.0
+Install-Package MouseKeyHook -Version 5.6.0
 ```
 
 ### 3. Crear Estructura de Carpetas
@@ -112,7 +112,7 @@ Uninstall-Package FontAwesome.Sharp
 Install-Package FontAwesome.Sharp -Version 6.3.0
 ```
 
-### Error: "GlobalMouseKeyHook no encontrado"
+### Error: "MouseKeyHook no encontrado"
 ```bash
 # Instalar dependencias adicionales
 Install-Package System.Windows.Forms


### PR DESCRIPTION
## Summary
- replace `GlobalMouseKeyHook` reference with `MouseKeyHook` in the project file
- update NuGet install instructions to use `MouseKeyHook`
- rename troubleshooting section accordingly

## Testing
- `dotnet restore`
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b6c6f2c08331bf8f0a0c4eb7ea28